### PR TITLE
Bump postcss to ^8.4.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function fetchResponsiveSizes(rule, declName, cb) {
   });
 }
 
-function fetchRangeSizes(rule, declName, cb){
+function fetchRangeSizes(rule, declName, cb) {
   rule.walkDecls(declName, decl => {
     let vals = decl.value.split(/\s+/);
 
@@ -200,16 +200,16 @@ function buildRules(rule, declName, params, result) {
   return rules;
 }
 
-module.exports = postcss.plugin('postcss-responsive-type', () => {
-  return function (css, result) {
-    css.walkRules(function(rule){
-      let thisRule,
-          newRules;
+const plugin = () => ({
+  postcssPlugin: 'postcss-responsive-type',
+  Once(root, { result }) {
+    root.walkRules(function (rule) {
+      let thisRule, newRules;
 
       // Check root font-size (for rem units)
-      if (rule.selector.indexOf('html') > -1){
+      if (rule.selector.indexOf('html') > -1) {
         rule.walkDecls('font-size', decl => {
-          if (decl.value.indexOf('px') > -1){
+          if (decl.value.indexOf('px') > -1) {
             rootSize = decl.value;
           }
         });
@@ -237,5 +237,9 @@ module.exports = postcss.plugin('postcss-responsive-type', () => {
         thisRule.parent.insertAfter(thisRule, newRules.maxMedia);
       });
     });
-  };
+  }
 });
+
+plugin.postcss = true;
+
+module.exports = plugin;

--- a/package.json
+++ b/package.json
@@ -25,13 +25,14 @@
     "url": "https://github.com/seaneking/postcss-responsive-type/issues"
   },
   "homepage": "https://github.com/seaneking/postcss-responsive-type",
-  "dependencies": {
-    "postcss": "^6.0.6"
-  },
   "devDependencies": {
     "chai": "^4.0.2",
     "eslint": "^4.1.1",
-    "mocha": "^3.4.2"
+    "mocha": "^3.4.2",
+    "postcss": "^8.4.6"
+  },
+  "peerDependencies": {
+    "postcss": "^8.4.6"
   },
   "scripts": {
     "test": "mocha test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,7 +136,7 @@ chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1:
+chalk@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
   dependencies:
@@ -664,6 +664,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
+nanoid@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -711,6 +716,11 @@ pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -729,13 +739,14 @@ pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
 
-postcss@^6.0.6:
-  version "6.0.8"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.8.tgz#89067a9ce8b11f8a84cbc5117efc30419a0857b3"
+postcss@^8.4.6:
+  version "8.4.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.6.tgz#c5ff3c3c457a23864f32cb45ac9b741498a09ae1"
+  integrity sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==
   dependencies:
-    chalk "^2.0.1"
-    source-map "^0.5.6"
-    supports-color "^4.2.0"
+    nanoid "^3.2.0"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -831,9 +842,10 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-source-map@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -878,7 +890,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^4.0.0, supports-color@^4.2.0:
+supports-color@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
   dependencies:


### PR DESCRIPTION
Refs: #39

This PR aims to bump postcss to version ^8.4.6

BREAKING CHANGES:
- Bump postcss to version ^8.4.6
